### PR TITLE
Allow nested partition keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ second, which would look like the following:
 { "myConstant": "Hello, World!", "randomNumber": 33}
 ```
 
+Partition keys can also be nested in the json as long as they are not nested in an array eg.
+
+```yaml
+topic: testTopic
+partitionKey: "nested.id"
+fields:
+  nested:
+    type: json
+    components:
+        id: "id123"
+```
+
+Will result in "id123" being used as the partition key.
+
 You can find a full example of config file in [this file](https://github.com/redBorder/synthetic-producer/blob/master/configProducer.yml)
 
 ## Fields types

--- a/src/test/java/net/redborder/utils/scheduler/StandardSchedulerTest.java
+++ b/src/test/java/net/redborder/utils/scheduler/StandardSchedulerTest.java
@@ -1,0 +1,45 @@
+package net.redborder.utils.scheduler;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.HashMap;
+import java.util.Map;
+import net.redborder.utils.producers.IProducer;
+import org.junit.Before;
+import org.junit.Test;
+
+public class StandardSchedulerTest {
+
+    private Map<String, Object> message;
+
+    private IProducer producer;
+
+    private StandardScheduler standardScheduler;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void before() throws Exception {
+
+        message = new HashMap<>();
+        message.put("id", "123");
+        message.put("nested", new HashMap<String, Object>());
+        ((Map<String, Object>) message.get("nested")).put("id", "345");
+
+        producer = mock(IProducer.class);
+
+        standardScheduler = new StandardScheduler(null, producer, 1D, 1);
+    }
+
+    @Test
+    public void extractPartitionKey() {
+        when(producer.getPartitionKey()).thenReturn("id");
+        String result = standardScheduler.extractPartitionKey(message);
+        assertEquals("123", result);
+
+        when(producer.getPartitionKey()).thenReturn("nested.id");
+        result = standardScheduler.extractPartitionKey(message);
+        assertEquals("345", result);
+    }
+}


### PR DESCRIPTION
This software is useful for testing and development, but partition keys are typically very important in enterprise software, especially for kafka streams and joins, and may be a nested value.

This PR allows the partition key to be a nested value.