### PR TITLE
Improvement/add rb event

### DIFF
--- a/packaging/rpm/synthetic-producer.spec
+++ b/packaging/rpm/synthetic-producer.spec
@@ -24,8 +24,7 @@ export MAVEN_OPTS="-Xmx512m -Xms256m -Xss10m -XX:MaxPermSize=512m" && mvn clean 
 mkdir -p %{buildroot}/usr/share/%{name}
 mkdir -p %{buildroot}/etc/%{name}/config
 install -D -m 644 target/%{name}-*-selfcontained.jar %{buildroot}/usr/share/%{name}/%{name}.jar
-install -D -m 644 yamls/rb_flow.yml %{buildroot}/etc/%{name}/config
-install -D -m 644 yamls/rb_state.yml %{buildroot}/etc/%{name}/config
+install -D -m 644 yamls/*.yml %{buildroot}/etc/%{name}/config
 
 %clean
 rm -rf %{buildroot}
@@ -47,6 +46,7 @@ exit 0
 /usr/share/%{name}/%{name}.jar
 /etc/%{name}/config/rb_flow.yml
 /etc/%{name}/config/rb_state.yml
+/etc/%{name}/config/rb_event.yml
 
 %changelog
 * Wed Jan 26 2022 Eduardo Reyes <eareyes@redborder.com> - 0.0.1

--- a/packaging/rpm/synthetic-producer.spec
+++ b/packaging/rpm/synthetic-producer.spec
@@ -51,6 +51,8 @@ exit 0
 /etc/%{name}/config/rb_event.yml
 
 %changelog
+* Mon Jul 15 2024 Luis Blanco <ljblanco@redborder.com> - 1.0.1-1
+- add all yamls in directory to include rb_event 
 * Wed Oct 4 2023 David Vanhoucke <dvanhoucke@redborder.com> - 1.0.0-1
 - sped update
 * Wed Jan 26 2022 Eduardo Reyes <eareyes@redborder.com> - 0.0.1

--- a/yamls/rb_event.yml
+++ b/yamls/rb_event.yml
@@ -1,11 +1,13 @@
+topic: rb_event
 fields:
-  topic: rb_event
+  timestamp:
+    type: timestamp
   sensor_id_snort:
     type: constant
     value: 0
   action: 
     type: constant
-    value: "alert"
+    value: 'alert'
   sig_generator:
     type: constant
     value: 1
@@ -18,127 +20,132 @@ fields:
   priority:
     type: collection
     values:
-      - "low"
-      - "medium"
-      - "high"
-      - "critical"
+    # - 'low'
+    # - 'medium'
+    - 'high'
+    # - 'critical'
   classification:
     type: constant
-    value: "Not Suspicious Traffic"
+    value: 'Not Suspicious Traffic'
   msg:
     type: constant
-    value: "Synthetic Alert"
+    value: 'ET POLICY Spotify P2P Client'
   payload:
     type: constant
-    value: "8469838455647030c05e4200ea9468e8000100044895c203fcedd42e25f41673f9b268c32a632c0fd3315000"
+    value: "4554205041434b4554204f5645524c4f41442041545441434b2044455445435445442046524f4d2031302e302e302e31"
   l4_proto:
     type: constant
     value: 17
   l4_proto_name:
     type: constant
-    value: "udp"
-  ethsrc":
+    value: 'udp'
+  ethsrc:
     type: constant
-    value: "00:00:00:00:00:00"
-  ethdst":
+    value: '00:00:00:00:00:00'
+  ethdst:
     type: constant
-    value: "00:00:00:00:00:00"
-ethsrc_vendor:
-  type: constant
-  value: "XEROX CORPORATION"
-ethdst_vendor:
-  type: constant
-  value: "XEROX CORPORATION"
-ethtype:
-  type: constant
-  value: 20736
-vlan:
-  type: constant
-  value: 0
-vlan_name:
-  type: constant
-  value: "0"
-udplength:
-  type: constant
-  value: 52
-ethlength:
-  type: constant
-  value: 0
-ethlength_range:
-  type: constant
-  value: "0(0-64]"
-src_port:
-  type: constant
-  value: 57621
-src_port_name:
-  type: constant
-  value: "57621"
-dst_port:
-  type: constant
-  value: 57621
-dst_port_name:
-  type: constant
-  value: "57621"
-src_asnum:
-  type: constant
-  value: 3508535562
-src:
-  type: constant
-  value: "0.0.0.0"
-src_name:
-  type: constant
-  value: "0.0.0.0"
-dst_asnum:
-  type: constant
-  value: "4280287498"
-dst_name:
-  type: constant
-  value: "9.9.9.9"
-dst:
-  type: constant
-  value: "9.9.9.9"
-ttl:
-  type: constant
-  value: 64
-tos:
-  type: constant
-  value: 0
-id:
-  type: constant
-  value: 22933
-iplen:
-  type: constant
-  value: 72
-iplen_range:
-  type: constant
-  value: "[64-128)"
-dgmlen:
-  type: constant
-  value: 72
-group_uuid:
-  type: constant
-  value: "00000000-0000-0000-0000-000000000000"
-group_name:
-  type: constant
-  value: "default"
-sensor_type:
-  type: constant
-  value: "ips"
-domain_name:
-  type: constant
-  value: "root"
-sensor_ip:
-  type: constant
-  value: "0.0.0.0"
-index_partitions:
-  type: constant
-  value: 5
-index_replicas:
-  type: constant
-  value: 1
-sensor_uuid:
-  type: constant
-  value: "00000000-0000-0000-0000-000000000000"
-sensor_name:
-  type: constant
-  value: "Virtual Synthetic Sensor"
+    value: '00:00:00:00:00:00'
+  ethsrc_vendor:
+    type: constant
+    value: 'XEROX CORPORATION'
+  ethdst_vendor:
+    type: constant
+    value: 'XEROX CORPORATION'
+  ethtype:
+    type: integer
+    min: 16384
+    max: 32767
+  vlan:
+    type: constant
+    value: 0
+  vlan_name:
+    type: constant
+    value: '0'
+  udplength:
+    type: constant
+    value: 60674
+  ethlength:
+    type: constant
+    value: 0
+  ethlength_range:
+    type: constant
+    value: '0(0-64]'
+  src_port:
+    type: constant
+    value: 57621
+  src_port_name:
+    type: constant
+    value: '57621'
+  dst_port:
+    type: constant
+    value: 57621
+  dst_port_name:
+    type: constant
+    value: '57621'
+  src_asnum:
+    type: integer
+    # negative: true
+    min: 1000000000
+    max: 4000000000
+  src:
+    type: ip
+    network: '10.1.32.0/24'
+  # src_name:
+  #   type: reference
+  #   field: src
+  dst_asnum:
+    type: constant
+    value: '4280287498'
+  dst:
+    type: constant
+    value: '10.1.32.255'
+  dst_name:
+    type: constant
+    value: '10.1.32.255'
+  ttl:
+    type: constant
+    value: 64
+  tos:
+    type: constant
+    value: 0
+  id:
+    type: integer
+    # negative: true
+    min: 0
+    max: 65535
+  iplen:
+    type: constant
+    value: 72
+  iplen_range:
+    type: constant
+    value: '[64-128)'
+  dgmlen:
+    type: constant
+    value: 72
+  group_uuid:
+    type: constant
+    value: '0277c7e0-aca7-42e9-807e-ed37dafb9d33'
+  group_name:
+    type: constant
+    value: 'default'
+  sensor_type:
+    type: constant
+    value: 'ips'
+  domain_name:
+    type: constant
+    value: 'root'
+  sensor_ip:
+    type: constant
+    value: '10.1.203.204'
+  index_partitions:
+    type: constant
+    value: 5
+  index_replicas:
+    type: constant
+    value: 1
+  sensor_uuid:
+    type: constant
+    value: '8d4ba045-5420-489f-86e6-e2512d094a44'
+  sensor_name:
+    type: constant
+    value: 'ips'

--- a/yamls/rb_event.yml
+++ b/yamls/rb_event.yml
@@ -1,0 +1,144 @@
+fields:
+  topic: rb_event
+  sensor_id_snort:
+    type: constant
+    value: 0
+  action: 
+    type: constant
+    value: "alert"
+  sig_generator:
+    type: constant
+    value: 1
+  sig_id:
+    type: constant
+    value: 2027397
+  rev:
+    type: constant
+    value: 2
+  priority:
+    type: collection
+    values:
+      - "low"
+      - "medium"
+      - "high"
+      - "critical"
+  classification:
+    type: constant
+    value: "Not Suspicious Traffic"
+  msg:
+    type: constant
+    value: "Synthetic Alert"
+  payload:
+    type: constant
+    value: "8469838455647030c05e4200ea9468e8000100044895c203fcedd42e25f41673f9b268c32a632c0fd3315000"
+  l4_proto:
+    type: constant
+    value: 17
+  l4_proto_name:
+    type: constant
+    value: "udp"
+  ethsrc":
+    type: constant
+    value: "00:00:00:00:00:00"
+  ethdst":
+    type: constant
+    value: "00:00:00:00:00:00"
+ethsrc_vendor:
+  type: constant
+  value: "XEROX CORPORATION"
+ethdst_vendor:
+  type: constant
+  value: "XEROX CORPORATION"
+ethtype:
+  type: constant
+  value: 20736
+vlan:
+  type: constant
+  value: 0
+vlan_name:
+  type: constant
+  value: "0"
+udplength:
+  type: constant
+  value: 52
+ethlength:
+  type: constant
+  value: 0
+ethlength_range:
+  type: constant
+  value: "0(0-64]"
+src_port:
+  type: constant
+  value: 57621
+src_port_name:
+  type: constant
+  value: "57621"
+dst_port:
+  type: constant
+  value: 57621
+dst_port_name:
+  type: constant
+  value: "57621"
+src_asnum:
+  type: constant
+  value: 3508535562
+src:
+  type: constant
+  value: "0.0.0.0"
+src_name:
+  type: constant
+  value: "0.0.0.0"
+dst_asnum:
+  type: constant
+  value: "4280287498"
+dst_name:
+  type: constant
+  value: "9.9.9.9"
+dst:
+  type: constant
+  value: "9.9.9.9"
+ttl:
+  type: constant
+  value: 64
+tos:
+  type: constant
+  value: 0
+id:
+  type: constant
+  value: 22933
+iplen:
+  type: constant
+  value: 72
+iplen_range:
+  type: constant
+  value: "[64-128)"
+dgmlen:
+  type: constant
+  value: 72
+group_uuid:
+  type: constant
+  value: "00000000-0000-0000-0000-000000000000"
+group_name:
+  type: constant
+  value: "default"
+sensor_type:
+  type: constant
+  value: "ips"
+domain_name:
+  type: constant
+  value: "root"
+sensor_ip:
+  type: constant
+  value: "0.0.0.0"
+index_partitions:
+  type: constant
+  value: 5
+index_replicas:
+  type: constant
+  value: 1
+sensor_uuid:
+  type: constant
+  value: "00000000-0000-0000-0000-000000000000"
+sensor_name:
+  type: constant
+  value: "Virtual Synthetic Sensor"


### PR DESCRIPTION
First version of basic rb_event synthetic generation. Most of the fields are currectly constant and we need to try this to check if is working for testing general purpose tasks with Intrusion.
On the other hand, notice rhel9 is a branch, so maybe development is not the branch to merge this.